### PR TITLE
AttributeError: module 'numpy' has no attribute 'float'

### DIFF
--- a/classes/pyETM.py
+++ b/classes/pyETM.py
@@ -2667,7 +2667,7 @@ class ETM:
             f = np.ones((l.shape[1],))
 
             sw = np.power(10, LIMIT - ss[ss > LIMIT])
-            sw[sw < np.finfo(np.float).eps] = np.finfo(np.float).eps
+            sw[sw < np.finfo(float).eps] = np.finfo(float).eps
             f[ss > LIMIT] = sw
 
             p.append(np.square(np.divide(f, factor[i])))
@@ -2728,7 +2728,7 @@ class ETM:
                 # (missing jump, etc) you end up with very unstable inversions
                 # f[f > 500] = 500
                 sw = np.power(10, LIMIT - s[s > LIMIT])
-                sw[sw < np.finfo(np.float).eps] = np.finfo(np.float).eps
+                sw[sw < np.finfo(float).eps] = np.finfo(float).eps
                 f[s > LIMIT] = sw
 
                 P = np.square(np.divide(f, factor))
@@ -2736,7 +2736,7 @@ class ETM:
                 break  # cst_pass = True
 
         # make sure there are no values below eps. Otherwise matrix becomes singular
-        P[P < np.finfo(np.float).eps] = 1e-6
+        P[P < np.finfo(float).eps] = 1e-6
 
         # some statistics
         SS = np.linalg.inv(np.dot(A.transpose(), np.multiply(P[:, None], A)))

--- a/classes/pyLeastSquares.py
+++ b/classes/pyLeastSquares.py
@@ -77,7 +77,7 @@ def robust_lsq(A, P, L, max_iter=10, gcc=True, limit=2.5, lat=0, lon=0):
             # (missing jump, etc) you end up with very unstable inversions
             # f[f > 500] = 500
             sw = np.power(10, LIMIT - s[s > LIMIT])
-            sw[sw < np.finfo(np.float).eps] = np.finfo(np.float).eps
+            sw[sw < np.finfo(float).eps] = np.finfo(float).eps
             f[s > LIMIT] = 1. / sw
 
             P = np.diag(np.divide(1, np.square(factor * f)))
@@ -87,7 +87,7 @@ def robust_lsq(A, P, L, max_iter=10, gcc=True, limit=2.5, lat=0, lon=0):
         iteration += 1
 
     # make sure there are no values below eps. Otherwise matrix becomes singular
-    P[P < np.finfo(np.float).eps] = 1e-6
+    P[P < np.finfo(float).eps] = 1e-6
     # some statistics
     SS = np.linalg.inv(np.dot(np.dot(A.transpose(), P), A))
 

--- a/classes/pyZTD.py
+++ b/classes/pyZTD.py
@@ -199,7 +199,7 @@ class Ztd(object):
                 # (missing jump, etc) you end up with very unstable inversions
                 # f[f > 500] = 500
                 sw = np.power(10, LIMIT - s[s > LIMIT])
-                sw[sw < np.finfo(np.float).eps] = np.finfo(np.float).eps
+                sw[sw < np.finfo(float).eps] = np.finfo(float).eps
                 f[s > LIMIT] = sw
 
                 P = np.square(np.divide(f, factor))
@@ -209,7 +209,7 @@ class Ztd(object):
             iteration += 1
 
         # make sure there are no values below eps. Otherwise matrix becomes singular
-        P[P < np.finfo(np.float).eps] = 1e-6
+        P[P < np.finfo(float).eps] = 1e-6
 
         # some statistics
         SS = np.linalg.inv(np.dot(A.transpose(), np.multiply(P[:, None], A)))

--- a/stacker/pyNEQStack.py
+++ b/stacker/pyNEQStack.py
@@ -78,7 +78,7 @@ def adjust_lsq(A, L, P=None):
             f = np.ones((v.shape[0],))
 
             sw = np.power(10, LIMIT - s[s > LIMIT])
-            sw[sw < np.finfo(np.float).eps] = np.finfo(np.float).eps
+            sw[sw < np.finfo(float).eps] = np.finfo(float).eps
 
             f[s > LIMIT] = sw
 

--- a/stacker/pyStack.py
+++ b/stacker/pyStack.py
@@ -67,7 +67,7 @@ def adjust_lsq(A, L, P=None):
             f = np.ones((v.shape[0],))
 
             sw = np.power(10, LIMIT - s[s > LIMIT])
-            sw[sw < np.finfo(np.float).eps] = np.finfo(np.float).eps
+            sw[sw < np.finfo(float).eps] = np.finfo(float).eps
 
             f[s > LIMIT] = sw
 


### PR DESCRIPTION
On numpy version 1.24.0, numpy.float, numpy.int and similar aliases were deprecated.
Now we must to use float, int, etc. instead.
More info: https://levelup.gitconnected.com/fix-attributeerror-module-numpy-has-no-attribute-float-d7d68c5a4971