### PR TITLE
Python Environmental file [merge]

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,71 +5,20 @@ Installation
 Prerequisites
 ---------------
 
-```sh
-apt-get install python3-venv
+These are easiest to install dependencies for Parallel.GAMIT is using
+[mamba](https://github.com/mamba-org/mamba); see
+[here](https://mamba.readthedocs.io/en/latest/index.html) for instructions on
+installing mamba.
+
+Once mamba is installed, the environment can be built (and activated) within
+the base directory of Parallel.GAMIT:
+
+```
+mamba env create -f environment.yml
+conda activate pgamit
 ```
 
-Libraries
-----------
-
-```sh
-export PROJ_DIR=/your/prefeered/path
-export PROJ_LIB=$PROJ_DIR/share/proj/
-
-mkdir /tmp/proj
-cd /tmp/proj
-wget https://download.osgeo.org/proj/proj-7.2.1.tar.gz
-tar xvfz proj-7.2.1.tar.gz
-cd proj-7.2.1
-./configure --prefix=$PROJ_DIR
-make install
-```
-
-Create and activate Python Environment
---------------------------------------------
-
-```sh
-python3 -m venv venv 
-source venv/bin/activate
-```
-
-Install Python packages
----------------------------
-
-```sh
-python -m pip install numpy==1.24.1
-python -m pip install wheel==0.37.1
-python -m pip install PyGreSQL==5.2.4
-python -m pip install scipy==1.10.0
-python -m pip install matplotlib==3.6.3
-python -m pip install tqdm==4.19.4
-python -m pip install scandir==1.10.0
-python -m pip install dispy==4.11.0
-python -m pip install netifaces==0.10.9
-python -m pip install psutil==5.6.3
-python -m pip install pycos==4.8.11
-python -m pip install dirsync==2.2.4
-python -m pip install simplekml==1.3.1
-python -m pip install hdf5storage==0.1.18
-# python -m pip install git+git://github.com/usgs/libcomcat.git@2.0.10
-# python -m pip install git+git://github.com/usgs/earthquake-impact-utils@0.8.27
-python -m pip install usgs-libcomcat
-python -m pip install requests==2.25.1
-python -m pip install obspy==1.2.2
-python -m pip install pandas
-python -m pip install shapely==2.0.0
-python -m pip install fiona==1.8.22
-python -m pip install openpyxl==3.0.7
-python -m pip install cartopy==0.21.1 
-python -m pip install scikit-learn==1.2.0
-# Required by pysftp/paramiko, newer versions require Rust to build
-python -m pip install cryptography==3.3.2
-python -m pip install paramiko==2.10.1
-python -m pip install pysftp==0.2.9
-python -m pip install country-converter
-python -m pip install geopy
-python -m pip install xmltodict
-```
-
-
+Alternatively, the `environment.yml` file contains all of the perquisites
+(with minimum required version numbers), which can be installed manually
+using pip.
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: pg
+name: pgamit
 channels:
   - conda-forge
   - defaults

--- a/environment.yml
+++ b/environment.yml
@@ -19,9 +19,7 @@ dependencies:
   - cryptography==37.0.4
   - cycler==0.10.0
   - dirsync>=2.2.4
-    #- earthquake-impact-utils==0.8.27
-    #- earthscope-cli==0.8.2
-    #- earthscope-sdk==0.2.0
+  - impactutils==0.8.40
   - Fiona>=1.8.19
   - geographiclib==2.0
   - geopy==2.4.1
@@ -69,4 +67,5 @@ dependencies:
     - PyGreSQL==5.2.5
     - country-converter #>=1.2
     - et-xmlfile #>=1.1.0
-
+    - earthscope-cli==0.8.2
+    - earthscope-sdk==0.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - python>=3.10.1 # Compatibility with Planetary Computer Base Install
   - attrs==21.2.0
   - bcrypt>=4.0.0
+  - basemap==1.4.0
   - cached-property==1.5.2
   - certifi>=2021.5.30
   - cffi==1.15.1
@@ -32,6 +33,7 @@ dependencies:
   - munch==2.5.0
   - netifaces==0.10.9
   - numpy==1.21.6
+  - networkx==3.3
   - openpyxl==3.0.7
   - pandas==1.4.1
   - paramiko==2.11.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,72 @@
+name: pg
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.10.1 # Compatibility with Planetary Computer Base Install
+  - attrs==21.2.0
+  - bcrypt>=4.0.0
+  - cached-property==1.5.2
+  - certifi>=2021.5.30
+  - cffi==1.15.1
+  - chardet==4.0.0
+  - charset-normalizer==3.1.0
+  - click==7.1.2
+  - click-plugins==1.1.1
+  - cligj==0.7.2
+  - colorama==0.4.6
+  - commonmark==0.9.1
+  - cryptography==37.0.4
+  - cycler==0.10.0
+  - dirsync>=2.2.4
+    #- earthquake-impact-utils==0.8.27
+    #- earthscope-cli==0.8.2
+    #- earthscope-sdk==0.2.0
+  - Fiona>=1.8.19
+  - geographiclib==2.0
+  - geopy==2.4.1
+  - h5py==3.4.0
+  - hdf5storage>=0.1.18
+  - idna==2.10
+  - joblib==1.0.1
+  - libcomcat==2.0.10
+  - matplotlib>=2.0.0
+  - munch==2.5.0
+  - netifaces==0.10.9
+  - numpy==1.21.6
+  - openpyxl==3.0.7
+  - pandas==1.4.1
+  - paramiko==2.11.0
+  - psutil>=5.6.3
+  - pycparser==2.21
+  - Pygments==2.14.0
+  - PyJWT==2.6.0
+  - PyNaCl==1.5.0
+  - pyparsing==2.4.7
+  - pysftp==0.2.9
+  - python-dateutil==2.8.2
+  - pytz==2021.1
+  - requests==2.28.2
+  - rich==12.6.0
+  - scandir>=1.6
+  - scikit-learn>=1.1
+  - scipy>=1.2.0
+  - Shapely>=1.7.1
+  - shellingham==1.5.0.post1
+  - simplekml==1.3.1
+  - six==1.16.0
+  - threadpoolctl==2.2.0
+  - tqdm==4.66.5
+  - typer==0.7.0
+  - typing_extensions==4.5.0
+  - urllib3==1.26.6
+  - xmltodict==0.13.0
+  - pip
+  - pip:
+    - overcluster
+    - pycos
+    - dispy #==4.15.2
+    - PyGreSQL==5.2.5
+    - country-converter #>=1.2
+    - et-xmlfile #>=1.1.0
+


### PR DESCRIPTION
This PR adds an `environment.yml` file for ParallelGamit. This file can be used by both pip for automating the install (i.e., future hosting of the ParallelGamit library on the pypi repository), and interactively by the developers and users to create reproducible production/development environments.

Use of this file is generally achieved by mamba and/or conda. For unity, mamba is available as a module which also includes a conda install.

To setup a fresh environment for the first time
----------------------------------------------

```
mamba env create -f environment.yml
conda activate pg
```

To update an existing environment after modifying `environment.yml`
---------------------------------------------------------------------

```
# make changes to environment.yml
conda deactivate # drop out of activated python env
mamba env update -n pg --file environment.yml
conda activate pg
```

To do
-------

Besides the first couple of items below, many of these will (likely) be separate pull requests in the future, but adding them here now for awareness:

- [x] Test environment for compatibility with current code base @eckendrick
- [ ] Prune unneeded dependencies. The dependency list was generated from the current working python environment on unity using 'pip freeze', which lists all installed python packages in site-packages. However, some of the packages listed are dependencies for mainline requirements (i.e., pandas is probably pulling in h5py), and this `environment.yml` will be shorter/clearer if we can remove the dependencies of dependencies (which are managed by the referring package itself at install time).
- [ ] Unpin (unneeded) version numbers. Right now, most everything has either an explicit version pinned, or a minimum version number specified. We would ideally only enforce this when actually needed so that the mamba/conda/pip installer are less constrained. (Note, we can still produce a `conda-lock` file for explicit reproducibility of production environments if needed, which would be separate from this `environment.yml` install file.) 
- [x] Update installation documentation; separate PR
- [ ] Add ParallelGamit to pypi. This would enable users to run `pip install ParallelGamit` to install, rather than doing either a git clone or manual install from a downloaded archive. Also would enable control and separation between development and production versions; separate PR

