### PR TITLE
Unit tests for BisectingQMeans and over_cluster

### DIFF
--- a/parallel_gamit/common.py
+++ b/parallel_gamit/common.py
@@ -1,0 +1,52 @@
+"""Common utilities for testing clustering."""
+
+# Author: Shane Grigsby (espg) <refuge@rocktalus.com>
+# Created: September 2024
+
+import numpy as np
+
+def gen_variable_density_clusters(n_points_per_cluster=250, seed=0):
+    """Generates 6 cluster blobs of varying density as synthetic continents 
+
+    Modified from the sklearn OPTICS example and unit tests. (see
+    https://scikit-learn.org/stable/auto_examples/cluster/plot_optics.html)"""
+
+    np.random.seed(seed)
+
+    C1 = [-5, -2] + 0.8 * np.random.randn(n_points_per_cluster, 2)
+    C2 = [4, -1] + 0.1 * np.random.randn(n_points_per_cluster, 2)
+    C3 = [1, -2] + 0.2 * np.random.randn(n_points_per_cluster, 2)
+    C4 = [-2, 3] + 0.3 * np.random.randn(n_points_per_cluster, 2)
+    C5 = [3, -2] + 1.6 * np.random.randn(n_points_per_cluster, 2)
+    C6 = [5, 6] + 2 * np.random.randn(n_points_per_cluster, 2)
+    X = np.vstack((C1, C2, C3, C4, C5, C6))
+
+    return X
+
+def generate_clustered_data(seed=0, n_clusters=3, n_features=2, 
+                            n_samples_per_cluster=20, std=0.4):
+    """Generic cluster generator (taken from sklearn common cluster tests)"""
+
+    prng = np.random.RandomState(seed)
+
+    # the data is voluntary shifted away from zero to check clustering
+    # algorithm robustness with regards to non centered data
+    means = (
+        np.array(
+            [
+                [1, 1, 1, 0],
+                [-1, -1, 0, 1],
+                [1, -1, 1, 1],
+                [-1, 1, 1, 0],
+            ]
+        )
+        + 10
+    )
+
+    X = np.empty((0, n_features))
+    for i in range(n_clusters):
+        X = np.r_[
+            X,
+            means[i][:n_features] + std * prng.randn(n_samples_per_cluster, n_features),
+        ]
+    return X

--- a/parallel_gamit/test_make_clusters.py
+++ b/parallel_gamit/test_make_clusters.py
@@ -1,0 +1,67 @@
+# Author: Shane Grigsby (espg) <refuge@rocktalus.com>
+# Created: September 2024
+
+import pytest
+import numpy as np
+
+from common import gen_variable_density_clusters, generate_clustered_data
+from utils import BisectingQMeans, over_cluster
+
+
+@pytest.mark.parametrize(
+    ("max_clust_size", "clust_size"),
+    [
+        [5, 10],
+        [7, 10],
+        [10, 50],
+        [15, 50],
+        [10, 250],
+        [20, 250],
+        [30, 250],
+    ],
+)
+def test_ceiling_variable_density(max_clust_size, clust_size):
+    """Test algorithmic guarantee of BisectingQMeans on variable density data
+    
+    Verify that when `min_clust_size=2`, that the max per cluster membership is
+    under (<, less than) what parameter `opt_cluster_size` is set to"""
+
+    data = gen_variable_density_clusters(clust_size)
+    clust = BisectingQMeans(min_clust_size=1, opt_clust_size=max_clust_size,
+                            init='random', n_init=50, algorithm='lloyd',
+                            max_iter=8000, random_state=42)
+    clust.fit(data)
+
+    _, counts = np.unique(clust.labels_, return_counts=True)
+    assert np.max(counts) < max_clust_size
+
+@pytest.mark.parametrize(
+    ("min_clust", "max_clust", "neighbors", "overlap"),
+    [
+        [1, 5, 5, 2],
+        [1, 10, 2, 5],
+        [1, 10, 5, 2],
+        [3, 15, 2, 5],
+        [3, 20, 1, 10],
+        [2, 17, 10, 1],
+    ],
+)
+def test_max_clust_expansion(min_clust, max_clust, neighbors, overlap):
+    """Test algorithmic guarantee of `over_cluster`
+
+    Verify that expanded cluster size is under (<=, less than or equal to):
+    [initial cluster size + (neighbors * overlap)]"""
+    
+    data = gen_variable_density_clusters()
+    clust = BisectingQMeans(min_clust_size=min_clust, opt_clust_size=max_clust,
+                            init='random', n_init=50, algorithm='lloyd',
+                            max_iter=8000, random_state=42)
+    clust.fit(data)
+ 
+    OC = over_cluster(clust.labels_, data, metric='euclidean',
+                      neighborhood=neighbors, overlap_points=overlap)
+
+    expanded_sizes = np.sum(OC, axis=1)
+    _, original_sizes = np.unique(clust.labels_, return_counts=True)
+    assert np.all((expanded_sizes - original_sizes) <= neighbors*overlap)
+


### PR DESCRIPTION
The test for `BisectingQMeans` checks to make sure that when `min_clust_size=1`, that the `opt_clust_size` parameter is treated as a hard limit. This test runs 7 permutations of data input size and maximum cluster ceiling. The data input is 6 generated synthetic input 'continents' of different point density, ranging from 10 points per 'continent' to 250 points per 'continent' (i.e., dataset sizes of 60 to 1,500). The cluster ceilings iterate over the sizes of 5, 7, 10, 15, 20, and 30.

The test for `over_cluster` verifies that the cluster membership expansion is bounded to inital cluster sizes plus the product of the two parameters that control the expansion, i.e.,  (`neighborhood` * `overlap_points`). There are 6 tests for this function, including three that run with output generated from `BisectingQMeans` with `min_clust_size=1`, and at a variety of parameter values for `neighborhood` and `overlap_points`.

As discussed in #101  , both of these unit tests pass currently, with no modifications to underlying production code. (see below)

```
espg@Max ~/s/P/parallel_gamit (tests)> py.test test_make_clusters.py                                    (pangeo) [21]
================================================ test session starts ================================================
platform darwin -- Python 3.11.4, pytest-8.0.2, pluggy-1.4.0
rootdir: /Users/espg/software/Parallel.GAMIT/parallel_gamit
plugins: anyio-4.3.0
collected 13 items                                                                                                  

test_make_clusters.py .............                                                                           [100%]

================================================ 13 passed in 44.01s ================================================
```

These unit tests are currently put in the "parallel_gamit" directory, which is **not** in line with best practices. Ideally we would like these in there own 'tests' directory, so that they are automatically called and run whenever someone submits a pull request to Parallel.GAMIT, so that we know before merging if the PR is impacting the expected behavior of anything that is touched by `make_clusters` inside of the **pyNetwork** file. However, setting this up would require adhering to the directory and python packaging changes that are being (eventually) tested in the pgamit branch 1.1.24. This is because the same changes that are needed to allow pip installation of pgamit are also needed to be in place to configure github to automate running of the tests-- that is, we need relative imports and the namespace within pgamit to adhere to standard python conventions.

There will be a separate PR to change `BisectingQMeans` so that we can enforce a hard limit on cluster sizes without setting `min_clust_size=1` , so we can have a max without forcing the overall distribution of clustering to change as happens when reverting to the base case of `min_clust_size=1` ; it should be easy to verify that using these unit tests, or slightly modified ones.