### PR TITLE
clustering algorithmic enhancements

### DIFF
--- a/parallel_gamit/utils.py
+++ b/parallel_gamit/utils.py
@@ -283,6 +283,10 @@ class BisectingQMeans(_BaseKMeans):
         (`opt_clust_size` - `min_clust_size`) are *a priori* ineligible to be
         bisected.
 
+    max_clust_size: int, default=35
+        Hard cutoff to bypass the heuristic when bisecting clusters; no
+        clusters greater than this size will be produced.
+
     init : {'k-means++', 'random'} or callable, default='random'
         Method for initialization:
 
@@ -381,6 +385,7 @@ class BisectingQMeans(_BaseKMeans):
         self,
         min_clust_size=4,
         opt_clust_size=20,
+        max_clust_size=35,
         *,
         init="random",
         n_init=1,
@@ -390,11 +395,11 @@ class BisectingQMeans(_BaseKMeans):
         tol=1e-4,
         copy_x=True,
         algorithm="lloyd",
-        n_clusters=2,
+        n_clusters=2,      # needed for base class, do not remove
     ):
         super().__init__(
-            n_clusters=n_clusters,
             init=init,
+            n_clusters=n_clusters,
             max_iter=max_iter,
             verbose=verbose,
             random_state=random_state,
@@ -404,6 +409,7 @@ class BisectingQMeans(_BaseKMeans):
 
         self.min_clust_size = min_clust_size
         self.opt_clust_size = opt_clust_size
+        self.max_clust_size = max_clust_size
         self.copy_x = copy_x
         self.algorithm = algorithm
         self.bisect = True
@@ -514,14 +520,16 @@ class BisectingQMeans(_BaseKMeans):
         # case where bisecting is not optimum
         if (counts[0] + counts[1]) < self.opt_clust_size:
             cluster_to_bisect.score = -np.inf
-        # bisect as long as the smallest child has membership of at least 4
+        # bisect as long as the smallest child meets membership constraints
         elif ((counts[0] >= self.min_clust_size) and
               (counts[1] >= self.min_clust_size)):
             cluster_to_bisect.split(best_labels, best_centers, scores)
         # one child will have membership of 3 or less; don't split
         else:
-            #pass
-            cluster_to_bisect.score = -np.inf
+            if (counts[0] + counts[1] >= self.max_clust_size):
+                cluster_to_bisect.split(best_labels, best_centers, scores)
+            else:
+                cluster_to_bisect.score = -np.inf
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y=None, sample_weight=None):

--- a/parallel_gamit/utils.py
+++ b/parallel_gamit/utils.py
@@ -63,8 +63,7 @@ def select_central_point(labels, coordinates, centroids,
 
 
 def over_cluster(labels, coordinates, metric='haversine', neighborhood=5,
-                 overlap_points=2,  method='edge', include_centroid=False,
-                 rejection_threshold=None, centriod_labels=None):
+                 overlap_points=2, rejection_threshold=None):
     """Expand cluster membership to include edge points of neighbor clusters
 
     Expands an existing clustering to create overlapping membership between
@@ -128,8 +127,7 @@ def over_cluster(labels, coordinates, metric='haversine', neighborhood=5,
         overlap. Should be less than the number of unique cluster labels - 1.
 
     overlap_points : int greater than or equal to 1, default=2
-        Should not exceed the size of the smallest cluster in `labels`, or
-        one less than that when `include_centroid` is set to 'True'.
+        Should not exceed the size of the smallest cluster in `labels`.
 
     rejection_threshold : float, default=None
         Determines if any potential overlapping points should be rejected for
@@ -151,6 +149,8 @@ def over_cluster(labels, coordinates, metric='haversine', neighborhood=5,
     # Returns already sorted
     clusters = np.unique(labels)
     n_clusters = len(clusters)
+
+    if (n_clusters - 1) < neighborhood: neighborhood = (n_clusters - 1)
 
     # reference index for reverse lookups
     ridx = np.array(list(range(len(labels))))
@@ -520,6 +520,7 @@ class BisectingQMeans(_BaseKMeans):
             cluster_to_bisect.split(best_labels, best_centers, scores)
         # one child will have membership of 3 or less; don't split
         else:
+            #pass
             cluster_to_bisect.score = -np.inf
 
     @_fit_context(prefer_skip_nested_validation=True)


### PR DESCRIPTION
This PR adds a new parameter to `BisectingQMeans` called `max_clust_size`. It also adds an explicit check to `over_cluster` for cases where the number of clusters being expanded is small (i.e., lower than the `neighborhood` parameter).

BisectingQMeans Updates
---------------------------

![image](https://github.com/user-attachments/assets/b5a455e8-a544-433b-a767-2299d2421f2c)

The image above is from #101 , and shows a case where we have a decent distribution of clusters except for one large and hard to split cluster that crashes the entire GAMIT run. Right now, we've been using `min_clust_size=1` to force the parameter `opt_cluster_size` to be treated as an absolute hard limit, specifically to take care of cases like this.

This is not ideal; parameters are meant to be used, and if we're always going to set `min_clust_size=1` in all cases to get some behavior, then it shouldn't be a settable parameter, it should just be hard coded. At the same time, there's a *reason* that we have a `min_clust_size` parameter in the first place-- it's so we can set a heuristic floor on the size of clusters produced, so that we don't end up with lots of very small station clusters. This PR introduces a new parameter, `max_clust_size`, that enforces the maximum cluster size *seperate* from the other two main parameters, so that we can still use `min_clust_size` and `opt_cluster_size` to control the distribution of clusters. 

Here's another image of a clustering run, and parameters that were used to produce it (this and all following figures are run on GAMIT project day 002 of 2022):

```clust = BisectingQMeans(min_clust_size=6, opt_clust_size=17, max_clust_size=np.inf, random_state=42)```

![baseCase](https://github.com/user-attachments/assets/bf936618-b450-4c4b-8a61-daabbf09e962)

The parameter `random_state=42` is for reproducibility, and I've set `max_clust_size=np.inf` so that it has no effect... i.e., this is showing our current production algorithm behavior. I've also `min_clust_size=6`, which is ensuring that we have some large clusters that can't be cleanly bisected; it's also a realistic minimum, since we don't want too small of station clusters. As seen above, this case produces some large clusters, including one that is probably too large to run on Unity.

This next figure keeps all the other parameters exactly the same, except it sets the new `max_clust_size` to a limit of 25:

```clust = BisectingQMeans(min_clust_size=6, opt_clust_size=17, max_clust_size=25, random_state=42)```

![improved](https://github.com/user-attachments/assets/a7593a98-fb7f-444d-8f71-7ea0098cfb30)

Ok, great, no more big clusters-- are largest cluster is 24, and the majority of clusters are between 10 and 20, which makes sense given our `opt_clust_size=17`. We have one degenerate cluster of membership 1, and a total of 3 small clusters that are size <=5 stations.

So, how does this compare to just using `min_clust_size=1`? Here's `min_clust_size=1` and `opt_clust_size=17`, which guarantees a ceiling of under 17:

```clust = BisectingQMeans(min_clust_size=1, opt_clust_size=17, max_clust_size=np.inf, random_state=42)```

![hardlimit17](https://github.com/user-attachments/assets/98ff9679-e7af-439e-98d2-650dc5a9b5fc)

Ok, so no big clusters, and quite a few produced that are bounded between 10 and 16. ***BUT***,  we also have quite a lot of degenerate small clusters-- there are 14 total stations of size <=5.

Well, the above isn't a totally fair comparison, since our hard limit on the new parameter was set to 25, not to 17... so how does the new algorithmic behavior compare to `min_clust_size=1` and `opt_clust_size=25`?

```clust = BisectingQMeans(min_clust_size=1, opt_clust_size=25, max_clust_size=np.inf, random_state=42)```

![hardlimit25](https://github.com/user-attachments/assets/46ebf6ba-8c06-4fed-9612-076b8f3b0f76)

Well, again, we aren't exceeding 25... and now we have 7 clusters that are of size <=5. ***HOWEVER***, we've also raised the number of total clusters that are near are hard limit of 25. Using the new parameter `max_clust_size=25` let us keep the other algorithm parameter `opt_clust_size` free, so we could assign it to 17... which means that when using all three parameters `(BisectingQMeans(min_clust_size=6, opt_clust_size=17, max_clust_size=25)`, we only have one cluster above twenty, and most station clusters are between 10 and 17. On the other hand, the case directly above has 20 clusters that have a membership of 20 stations or more.

