### PR TITLE
Pruning function

### DIFF
--- a/pgamit/cluster.py
+++ b/pgamit/cluster.py
@@ -35,7 +35,7 @@ def prune(OC, method='linear'):
         subset = []
         for i, row in enumerate(OC):
             mod = OC.copy()
-            mod[i, :] = np.zeros(len(stations))
+            mod[i, :] = np.zeros(len(row))
             counts = mod.sum(axis=0)
             problems = np.sum(counts == 0)
             if problems == 0:

--- a/pgamit/cluster.py
+++ b/pgamit/cluster.py
@@ -18,6 +18,7 @@ from sklearn.cluster._k_means_common import _inertia_dense, _inertia_sparse
 from sklearn.cluster._kmeans import (_BaseKMeans, _kmeans_single_elkan,
                                      _kmeans_single_lloyd)
 
+
 def prune(OC, method='linear'):
     """Prune redundant clusters from over cluster (OC) array
 
@@ -40,7 +41,7 @@ def prune(OC, method='linear'):
             problems = np.sum(counts == 0)
             if problems == 0:
                 subset.append(i)
-                OC[i,:] = np.zeros(len(row))
+                OC[i, :] = np.zeros(len(row))
         return OC[~np.array(subset)]
     else:
         return OC
@@ -177,7 +178,8 @@ def over_cluster(labels, coordinates, metric='haversine', neighborhood=5,
     clusters = np.unique(labels)
     n_clusters = len(clusters)
 
-    if (n_clusters - 1) < neighborhood: neighborhood = (n_clusters - 1)
+    if (n_clusters - 1) < neighborhood:
+        neighborhood = (n_clusters - 1)
 
     # reference index for reverse lookups
     ridx = np.array(list(range(len(labels))))
@@ -664,4 +666,3 @@ class _BisectingTree:
         else:
             yield from self.left.iter_leaves()
             yield from self.right.iter_leaves()
-

--- a/pgamit/cluster.py
+++ b/pgamit/cluster.py
@@ -18,6 +18,33 @@ from sklearn.cluster._k_means_common import _inertia_dense, _inertia_sparse
 from sklearn.cluster._kmeans import (_BaseKMeans, _kmeans_single_elkan,
                                      _kmeans_single_lloyd)
 
+def prune(OC, method='linear'):
+    """Prune redundant clusters from over cluster (OC) array
+
+    Parameters
+    ----------
+
+    OC : bool array of shape (n_clusters, n_coordinates)
+    method : ["linear", None]; defaults linear scan
+
+    Returns
+
+    OC : Pruned bool array of shape (n_clusters, n_coordinates)
+    """
+    if method is "linear":
+        subset = []
+        for i, row in enumerate(OC)
+            mod = OC.copy()
+            mod[i, :] = np.zeros(len(stations))
+            counts = mod.sum(axis=0)
+            problems = np.sum(counts == 0)
+            if problems == 0:
+                subset.append(i)
+                OC[i,:] = np.zeros(len(stations))
+        return OC[~np.array(subset)]
+    else:
+        return OC
+
 
 def select_central_point(labels, coordinates, centroids,
                          metric='euclidean'):

--- a/pgamit/cluster.py
+++ b/pgamit/cluster.py
@@ -33,7 +33,7 @@ def prune(OC, method='linear'):
     """
     if method is "linear":
         subset = []
-        for i, row in enumerate(OC)
+        for i, row in enumerate(OC):
             mod = OC.copy()
             mod[i, :] = np.zeros(len(stations))
             counts = mod.sum(axis=0)

--- a/pgamit/cluster.py
+++ b/pgamit/cluster.py
@@ -40,7 +40,7 @@ def prune(OC, method='linear'):
             problems = np.sum(counts == 0)
             if problems == 0:
                 subset.append(i)
-                OC[i,:] = np.zeros(len(stations))
+                OC[i,:] = np.zeros(len(row))
         return OC[~np.array(subset)]
     else:
         return OC

--- a/pgamit/cluster.py
+++ b/pgamit/cluster.py
@@ -31,7 +31,7 @@ def prune(OC, method='linear'):
 
     OC : Pruned bool array of shape (n_clusters, n_coordinates)
     """
-    if method is "linear":
+    if method == "linear":
         subset = []
         for i, row in enumerate(OC):
             mod = OC.copy()

--- a/pgamit/network.py
+++ b/pgamit/network.py
@@ -39,8 +39,6 @@ from pgamit.pyGamitSession import GamitSession
 from pgamit.pyStation import StationCollection
 from pgamit.cluster import (BisectingQMeans, over_cluster, prune, 
                             select_central_point)
-from pgamit.cluster import 
-prune
 from pgamit.plots import plot_global_network
 
 BACKBONE_NET = 45

--- a/pgamit/network.py
+++ b/pgamit/network.py
@@ -37,7 +37,10 @@ from scipy.spatial import Delaunay, distance
 # app
 from pgamit.pyGamitSession import GamitSession
 from pgamit.pyStation import StationCollection
-from pgamit.cluster import over_cluster, select_central_point, BisectingQMeans
+from pgamit.cluster import (BisectingQMeans, over_cluster, prune, 
+                            select_central_point)
+from pgamit.cluster import 
+prune
 from pgamit.plots import plot_global_network
 
 BACKBONE_NET = 45
@@ -186,6 +189,8 @@ class Network(object):
         # expand the initial clusters to overlap stations with neighbors
         OC = over_cluster(qmean.labels_, points, metric='euclidean',
                           neighborhood=5, overlap_points=2)
+        # set 'method=None' to disable
+        OC = prune(OC, method='linear')
         # calculate all 'tie' stations
         ties = np.where(np.sum(OC, axis=0) > 1)[0]
         # monotonic labels, compatible with previous data structure / api


### PR DESCRIPTION
Implements a simple linear scan to prune redundant clusters.

Here's my testing on a modified verbose version that displays clusters removed:

```python
%%time
subset, OC = prune(b)
subset

CPU times: user 7.73 ms, sys: 2.35 ms, total: 10.1 ms
Wall time: 9.73 ms
[0, 10, 15, 19, 21, 22, 25, 31, 32, 46, 47, 67, 74, 77, 83]
```

Original clustering above had 90 clusters, so 15 removed is a little under 20% improvement (1/6th reduction).

Setting `method=None` in `network.py` disables the pruning filter. 

