### PR TITLE
bandaid fix for indexing error

### DIFF
--- a/pgamit/cluster.py
+++ b/pgamit/cluster.py
@@ -19,8 +19,8 @@ from sklearn.cluster._kmeans import (_BaseKMeans, _kmeans_single_elkan,
                                      _kmeans_single_lloyd)
 
 
-def prune(OC, method='linear'):
-    """Prune redundant clusters from over cluster (OC) array
+def prune(OC, central_points, method='linear'):
+    """Prune redundant clusters from over cluster (OC) and other arrays
 
     Parameters
     ----------
@@ -30,7 +30,8 @@ def prune(OC, method='linear'):
 
     Returns
 
-    OC : Pruned bool array of shape (n_clusters, n_coordinates)
+    OC : Pruned bool array of shape (n_clusters - N, n_coordinates)
+    central_points : Pruned int array of shape (n_clusters -N,)
     """
     if method == "linear":
         subset = []
@@ -42,13 +43,12 @@ def prune(OC, method='linear'):
             if problems == 0:
                 subset.append(i)
                 OC[i, :] = np.zeros(len(row))
-        return OC[~np.array(subset)]
+        return OC[~np.array(subset)], central_points[~np.array(subset)]
     else:
-        return OC
+        return OC, central_points
 
 
-def select_central_point(labels, coordinates, centroids,
-                         metric='euclidean'):
+def select_central_point(coordinates, centroids, metric='euclidean'):
     """Select the nearest central point in a given neighborhood
 
     Note this code explicitly assumes that centroids are passed from a
@@ -61,8 +61,6 @@ def select_central_point(labels, coordinates, centroids,
     Parameters
     ----------
 
-    labels : ndarray of type int, and shape (n_samples,)
-        Cluster labels for each point in the dataset from prior clustering.
     coordinates : ndarray of shape (n_samples, n_features)
         Coordinates do not need to match what was used for the prior
         clustering; i.e., if 'Euclidean' was used to calculate the prior

--- a/pgamit/network.py
+++ b/pgamit/network.py
@@ -182,15 +182,15 @@ class Network(object):
         qmean = BisectingQMeans(min_size=2, random_state=42)
         qmean.fit(points)
         # snap centroids to closest station coordinate
-        central_points = select_central_point(qmean.labels_, points,
-                                              qmean.cluster_centers_)
+        central_points = select_central_point(points, qmean.cluster_centers_)
         # expand the initial clusters to overlap stations with neighbors
         OC = over_cluster(qmean.labels_, points, metric='euclidean',
                           neighborhood=5, overlap_points=2)
         # set 'method=None' to disable
-        OC = prune(OC, method='linear')
+        OC, central_points = prune(OC, central_points, method='linear')
         # calculate all 'tie' stations
         ties = np.where(np.sum(OC, axis=0) > 1)[0]
+
         # monotonic labels, compatible with previous data structure / api
         cluster_labels = []
         station_labels = []


### PR DESCRIPTION
quickfix for #161 ; cleanest way I could think to do this-- folds in the `central_points` array to the same `prune` filter function as the cluster array itself.

...is there general utility in having `central_points` beyond this plotting call? https://github.com/demiangomez/Parallel.GAMIT/blob/ac471fd71890a9e7363de97f97d4d80bc08390e6/pgamit/network.py#L226-L227

i.e., do we actually use these once they get passed to gamitsession and written to the database?