### PR TITLE
Fix for failing test

### DIFF
--- a/pgamit/tests/test_make_clusters.py
+++ b/pgamit/tests/test_make_clusters.py
@@ -58,8 +58,9 @@ def test_max_clust_expansion(min_clust, max_clust, neighbors, overlap):
                             max_iter=8000, random_state=42)
     clust.fit(data)
  
-    OC = over_cluster(clust.labels_, data, metric='euclidean',
-                      neighbors=neighbors, overlap_points=overlap)
+    OC = over_cluster(clust.labels_, data, metric='euclidean', 
+                      neighbors=neighbors, overlap_points=overlap,
+                      method='dynamic')
 
     expanded_sizes = np.sum(OC, axis=1)
     _, original_sizes = np.unique(clust.labels_, return_counts=True)


### PR DESCRIPTION
`over_cluster` was modified to default to the new 'static' keyword for the `method` parameter; this fixes the failing test by telling it to run on the previous version instead of the new method (new method will need it's own test).