### PR TITLE
new `paired` method for `over_cluster()` function

### DIFF
--- a/pgamit/network.py
+++ b/pgamit/network.py
@@ -187,7 +187,7 @@ class Network(object):
         central_points = select_central_point(points, qmean.cluster_centers_)
         # expand the initial clusters to overlap stations with neighbors
         OC = over_cluster(qmean.labels_, points, metric='euclidean',
-                          neighbors=self.ties, overlap_points=2)
+                          neighbors=self.ties, overlap=2)
         # set 'method=None' to disable
         OC, central_points = prune(OC, central_points, method='minsize')
         # calculate all 'tie' stations

--- a/pgamit/tests/test_make_clusters.py
+++ b/pgamit/tests/test_make_clusters.py
@@ -58,8 +58,9 @@ def test_max_clust_expansion(min_clust, max_clust, neighbors, overlap):
                             max_iter=8000, random_state=42)
     clust.fit(data)
  
-    OC = over_cluster(clust.labels_, data, metric='euclidean',
-                      neighbors=neighbors, overlap_points=overlap)
+    OC = over_cluster(clust.labels_, data, metric='euclidean', 
+                      neighbors=neighbors, overlap_points=overlap,
+                      method='dynamic')
 
     expanded_sizes = np.sum(OC, axis=1)
     _, original_sizes = np.unique(clust.labels_, return_counts=True)


### PR DESCRIPTION
This is an enhancement / test case that we had discussed previously-- it expands cluster membership in 'pairs' by adding the closest point from an adjacent cluster along with a distant point from that same cluster to (potentially) improve the baseline estimation and water vapor correction within GAMIT runs. For most cases, the 'distant point' will be the furthest point from the neighboring cluster... however, we check against the `rejection_threshold` (with a default value of 5,000km), so in some cases it will instead be the furthest point under that threshold.

This PR has a few other changes that are worth mentioning. The parameter `overlap_points` has been renamed to just `overlap` to help with line lengths, and the `rejection_threshold` has been set to a default value of 5,000,000 meters. This latter point may have some effect on repeat runs, since earlier it was set to `None`-- i.e., if the baseline distance was exceeded, we'd see the error in the GAMIT output. Now, with this update, there shouldn't be GAMIT errors related to baseline length. The documentation has been updated, and some additional pep8 fixes within the cluster.py module have also been implemented... it still needs more to be pep8 'compliant' since the agglomerative clustering function added several hundred new lines to the file, but the easier to fix errors have been fixed.

Besides the new `paired` method itself, the biggest update in this PR is the fix for a bug that's been present for a while. Previously, setting neighbors=N for the default static method would add N+1 new points per cluster, instead of just N points per cluster as is described in the documentation. This was a zero indexing bug; the while loop checked for a condition <= neighbors, and started at 0. So, if you set neighbors=2, the termination condition wouldn't be met until the number of neighbors added was '3'. This is fixed now-- `method='static'` and `neighbors=N` will yield N points added to each cluster, for n_clusters * neighbors additional redundant tie points that need to be processed for the GAMIT subnetwork runs. However, this behavior (while correct) is **different** than what it was when running previous pgamit runs-- new runs will need to update there parameters appropriately to be comparable. As for the the new `paired` method, it will produce ties to N=neighbors adjacent clusters, with each neighbor always including exactly two tie points-- i.e., neighbors*2*n_clusters additional redundant tie points.